### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,8 @@
     ],
     "require": {
         "php": ">=5.5.9",
-        "illuminate/support": ">=5.1",
-        "illuminate/view": ">=5.1"
+        "illuminate/support": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*",
+        "illuminate/view": "5.1.* || 5.2.* || 5.3.* || 5.4.* || 5.5.*"
     },
     "require-dev": {
         "mockery/mockery": "~0.9",


### PR DESCRIPTION
Laravel doesn't follow semver. So having `^5.x`, `5.*` or `>=5.x` will mean that composer will install a future version even though that version breaks the package.