### PR TITLE
Padronization and unit test corrections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 composer.phar
 composer.lock
 .DS_Store
+.idea

--- a/src/Currency.php
+++ b/src/Currency.php
@@ -422,7 +422,7 @@ class Currency implements Arrayable, Jsonable, JsonSerializable, Renderable
             return '';
         }
 
-        return ' ' . $this->symbol;
+        return $this->symbol;
     }
 
     /**

--- a/tests/CurrencyTest.php
+++ b/tests/CurrencyTest.php
@@ -6,8 +6,9 @@ class CurrencyTest extends PHPUnit_Framework_TestCase
 {
     public function testFactoryMethods()
     {
+        $TRY = 'TRY';
         $this->assertEquals(Currency::USD(), new Currency('USD'));
-        $this->assertEquals(Currency::TRY(), new Currency('TRY'));
+        $this->assertEquals(Currency::$TRY(), new Currency('TRY'));
     }
 
     /**

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -12,8 +12,9 @@ class MoneyTest extends PHPUnit_Framework_TestCase
 
     public function testFactoryMethods()
     {
+        $TRY = 'TRY';
         $this->assertEquals(Money::USD(25), Money::USD(10)->add(Money::USD(15)));
-        $this->assertEquals(Money::TRY(25), Money::TRY(10)->add(Money::TRY(15)));
+        $this->assertEquals(Money::$TRY(25), Money::$TRY(10)->add(Money::$TRY(15)));
     }
 
     public function testBigValue()
@@ -276,13 +277,14 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testCallbackFormatLocale()
     {
         $m = new Money(1, new Currency('USD'));
+
         $actual = $m->formatLocale(null, function (NumberFormatter $formatter) {
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 0);
         });
 
-        $formatter = new NumberFormatter(Money::getLocale(), NumberFormatter::CURRENCY);
+        $formatter = new NumberFormatter($m::getLocale(), NumberFormatter::CURRENCY);
         $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 0);
-        $expected = $formatter->formatCurrency(0, 'USD');
+        $expected = $formatter->formatCurrency('0.01', 'USD');
 
         $this->assertEquals($expected, $actual);
     }

--- a/tests/MoneyTest.php
+++ b/tests/MoneyTest.php
@@ -18,13 +18,13 @@ class MoneyTest extends PHPUnit_Framework_TestCase
 
     public function testBigValue()
     {
-        $this->assertEquals((string) new Money(123456789.321, new Currency('USD'), true), '$123.456.789,32');
+        $this->assertEquals((string) new Money(123456789.321, new Currency('USD'), true), '$123,456,789.32');
     }
 
     public function testValueString()
     {
         $this->assertEquals(new Money('1', new Currency('USD')), new Money(1, new Currency('USD')));
-        $this->assertEquals(new Money('1,1', new Currency('USD')), new Money(1.1, new Currency('USD')));
+        $this->assertEquals(new Money('1.1', new Currency('USD')), new Money(1.1, new Currency('USD')));
     }
 
     public function testValueFunction()
@@ -91,8 +91,8 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     public function testSameCurrency()
     {
         $m = new Money(100, new Currency('USD'));
-        $this->assertFalse($m->isSameCurrency(new Money(100, new Currency('USD'))));
-        $this->assertTrue($m->isSameCurrency(new Money(100, new Currency('TRY'))));
+        $this->assertTrue($m->isSameCurrency(new Money(100, new Currency('USD'))));
+        $this->assertFalse($m->isSameCurrency(new Money(100, new Currency('TRY'))));
     }
 
     public function testComparison()
@@ -269,8 +269,6 @@ class MoneyTest extends PHPUnit_Framework_TestCase
     {
         return [
             ['₺1.548,48', 'TRY', 154848.25895, 'tr_TR', 'Example: ' . __LINE__],
-            ['TR₺1,548.48', 'TRY', 154848.25895, 'tr_TR', 'Example: ' . __LINE__],
-            ['US$0,48', 'USD', 48.25, 'en_US', 'Example: ' . __LINE__],
             ['$1,548.48', 'USD', 154848.25895, 'en_US', 'Example: ' . __LINE__],
         ];
     }
@@ -282,7 +280,11 @@ class MoneyTest extends PHPUnit_Framework_TestCase
             $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 0);
         });
 
-        $this->assertEquals('$0', $actual);
+        $formatter = new NumberFormatter(Money::getLocale(), NumberFormatter::CURRENCY);
+        $formatter->setAttribute(NumberFormatter::MAX_FRACTION_DIGITS, 0);
+        $expected = $formatter->formatCurrency(0, 'USD');
+
+        $this->assertEquals($expected, $actual);
     }
 
     public function testFormatSimple()


### PR DESCRIPTION
Removed empty space from currency’s suffix to comply with tests and padronization;
Fixed format and punctuation of MoneyTest’s assertions tests.