### PR TITLE
Change name and symbol PEN

### DIFF
--- a/src/Config/money.php
+++ b/src/Config/money.php
@@ -1202,11 +1202,11 @@ return [
     ],
 
     'PEN' => [
-        'name'                => 'Nuevo Sol',
+        'name'                => 'Sol',
         'code'                => 604,
         'precision'           => 2,
         'subunit'             => 100,
-        'symbol'              => 'S/.',
+        'symbol'              => 'S/',
         'symbol_first'        => true,
         'decimal_mark'        => '.',
         'thousands_separator' => ',',


### PR DESCRIPTION
The PEN code corresponds to Peru. By [Law](http://www.bcrp.gob.pe/docs/Transparencia/Normas-Legales/Circulares/2015/circular-047-2015-bcrp.pdf) the denomination and the symbol of the currency in Peru is changed.

![money](https://user-images.githubusercontent.com/22132891/53295427-3f367b00-37c9-11e9-91cc-6d678ff4b924.png)

