### PR TITLE
Fixed bug when converting currencies stronger than base currency

### DIFF
--- a/src/Money.php
+++ b/src/Money.php
@@ -535,7 +535,7 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
         $this->assertOperand($ratio);
         $this->assertRoundingMode($roundingMode);
 
-        if ($ratio < 1) {
+        if ($ratio > 1) {
             return $this->divide($ratio, $roundingMode);
         }
 

--- a/src/Money.php
+++ b/src/Money.php
@@ -535,10 +535,6 @@ class Money implements Arrayable, Jsonable, JsonSerializable, Renderable
         $this->assertOperand($ratio);
         $this->assertRoundingMode($roundingMode);
 
-        if ($ratio > 1) {
-            return $this->divide($ratio, $roundingMode);
-        }
-
         return $this->multiply($ratio, $roundingMode);
     }
 


### PR DESCRIPTION
In the previous logic, if the ratio is less than 1, it divides, otherwise it multiplies. This only works if the converted currency is stronger than the base currency.

For example: if the base currency is US Dollar and the converted currency is EURO, the ratio could be 1,14 (EUR to USD) or 0,88 (USD to EUR). So if i want to convert EUR 100 in the first case it will divide, in the second multiply but we will always get USD 114 as a result.

The problem with this logic is when converting currencies which are not stronger than USD.
For example: if the converted currency is Uruguayan Peso, the ratio will be 33 (1 USD = 33 UYU).
With the previous logic, the conversion would have been 100 UYU = 3300 USD, **which is wrong**.

So my proposal is change the logic, and always multiply. So the ratio should always be: **from converted currency to base currency.** 
To summarize, if 1 converted currency = X Base Currency, then Ratio = X.

