### PR TITLE
Add Laravel 13 and PHP 8.5 support

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         php: ['8.2', '8.3', '8.4']
-        laravel: [10.*, 11.*, 12.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
@@ -20,6 +20,8 @@ jobs:
             testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
 
     steps:
       - name: Checkout code

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,11 +9,16 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
-        laravel: [12.*, 13.*]
+        laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
+          - laravel: 10.*
+            testbench: 8.*
+          - laravel: 11.*
+            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,9 @@ jobs:
     strategy:
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
-        laravel: [11.*, 12.*, 13.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 11.*
-            testbench: 9.*
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
           - laravel: 10.*
             testbench: 8.*
           - laravel: 11.*
-            testbench: 9.*
+            testbench: ^9.1.4
           - laravel: 12.*
             testbench: 10.*
           - laravel: 13.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         php: ['8.2', '8.3', '8.4']
         laravel: [10.*, 11.*, 12.*, 13.*]
-        stability: [prefer-lowest, prefer-stable]
+        stability: [prefer-stable]
         include:
           - laravel: 10.*
             testbench: 8.*

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,11 +11,9 @@ jobs:
     strategy:
       matrix:
         php: ['8.2', '8.3', '8.4', '8.5']
-        laravel: [10.*, 11.*, 12.*, 13.*]
-        stability: [prefer-stable]
+        laravel: [11.*, 12.*, 13.*]
+        stability: [prefer-lowest, prefer-stable]
         include:
-          - laravel: 10.*
-            testbench: 8.*
           - laravel: 11.*
             testbench: 9.*
           - laravel: 12.*
@@ -28,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ['8.2', '8.3', '8.4']
+        php: ['8.2', '8.3', '8.4', '8.5']
         laravel: [10.*, 11.*, 12.*, 13.*]
         stability: [prefer-stable]
         include:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,6 +22,9 @@ jobs:
             testbench: 10.*
           - laravel: 13.*
             testbench: 11.*
+        exclude:
+          - laravel: 13.*
+            php: '8.2'
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
       "vlucas/phpdotenv": "^5.4.1"
    },
    "require-dev": {
-      "phpunit/phpunit": "^10.5|^11.0",
+      "phpunit/phpunit": "^10.5|^11.5.50|^12.5.8",
       "orchestra/testbench": "^8.0|^9.0|^10|^11",
       "vimeo/psalm": "^6.0"
    },

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
    },
    "require-dev": {
       "phpunit/phpunit": "^10.5|^11.5.50|^12.5.8",
-      "orchestra/testbench": "^8.0|^9.0|^10|^11",
+      "orchestra/testbench": "^8.0|^9.1.4|^10|^11",
       "vimeo/psalm": "^6.0"
    },
    "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
    ],
    "require": {
       "php": "^8.2",
-      "illuminate/contracts": "^11.0|^12|^13",
-      "illuminate/support": "^11.0|^12|^13",
-      "illuminate/validation": "^11.0|^12|^13",
-      "illuminate/view": "^11.0|^12|^13",
+      "illuminate/contracts": "^12|^13",
+      "illuminate/support": "^12|^13",
+      "illuminate/validation": "^12|^13",
+      "illuminate/view": "^12|^13",
       "vlucas/phpdotenv": "^5.4.1"
    },
    "require-dev": {
-      "phpunit/phpunit": "^10.5|^11.5.50|^12.5.8",
-      "orchestra/testbench": "^9.0|^10|^11",
+      "phpunit/phpunit": "^11.5.50|^12.5.8",
+      "orchestra/testbench": "^10|^11",
       "vimeo/psalm": "^6.0"
    },
    "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
    ],
    "require": {
       "php": "^8.2",
-      "illuminate/contracts": "^10.0|^11.0|^12|^13",
-      "illuminate/support": "^10.0|^11.0|^12|^13",
-      "illuminate/validation": "^10.0|^11.0|^12|^13",
-      "illuminate/view": "^10.0|^11.0|^12|^13",
+      "illuminate/contracts": "^11.0|^12|^13",
+      "illuminate/support": "^11.0|^12|^13",
+      "illuminate/validation": "^11.0|^12|^13",
+      "illuminate/view": "^11.0|^12|^13",
       "vlucas/phpdotenv": "^5.4.1"
    },
    "require-dev": {
       "phpunit/phpunit": "^10.5|^11.5.50|^12.5.8",
-      "orchestra/testbench": "^8.0|^9.0|^10|^11",
+      "orchestra/testbench": "^9.0|^10|^11",
       "vimeo/psalm": "^6.0"
    },
    "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
    ],
    "require": {
       "php": "^8.2",
-      "illuminate/contracts": "^10.0|^11.0|^12",
-      "illuminate/support": "^10.0|^11.0|^12",
-      "illuminate/validation": "^10.0|^11.0|^12",
-      "illuminate/view": "^10.0|^11.0|^12",
+      "illuminate/contracts": "^10.0|^11.0|^12|^13",
+      "illuminate/support": "^10.0|^11.0|^12|^13",
+      "illuminate/validation": "^10.0|^11.0|^12|^13",
+      "illuminate/view": "^10.0|^11.0|^12|^13",
       "vlucas/phpdotenv": "^5.4.1"
    },
    "require-dev": {
       "phpunit/phpunit": "^10.5|^11.0",
-      "orchestra/testbench": "^8.0|^9.0|^10",
+      "orchestra/testbench": "^8.0|^9.0|^10|^11",
       "vimeo/psalm": "^6.0"
    },
    "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,15 +19,15 @@
    ],
    "require": {
       "php": "^8.2",
-      "illuminate/contracts": "^12|^13",
-      "illuminate/support": "^12|^13",
-      "illuminate/validation": "^12|^13",
-      "illuminate/view": "^12|^13",
+      "illuminate/contracts": "^10.0|^11.0|^12|^13",
+      "illuminate/support": "^10.0|^11.0|^12|^13",
+      "illuminate/validation": "^10.0|^11.0|^12|^13",
+      "illuminate/view": "^10.0|^11.0|^12|^13",
       "vlucas/phpdotenv": "^5.4.1"
    },
    "require-dev": {
-      "phpunit/phpunit": "^11.5.50|^12.5.8",
-      "orchestra/testbench": "^10|^11",
+      "phpunit/phpunit": "^10.5|^11.5.50|^12.5.8",
+      "orchestra/testbench": "^8.0|^9.0|^10|^11",
       "vimeo/psalm": "^6.0"
    },
    "autoload": {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,10 +3,14 @@
 namespace Akaunting\Money\Tests;
 
 use Akaunting\Money\Provider;
+use Illuminate\Testing\TestResponse;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
+    // Older Testbench releases expect the concrete test case to provide this.
+    protected static ?TestResponse $latestResponse = null;
+
     protected function getPackageProviders($app): array
     {
         return [Provider::class];

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -9,7 +9,7 @@ use Orchestra\Testbench\TestCase as BaseTestCase;
 class TestCase extends BaseTestCase
 {
     // Older Testbench releases expect the concrete test case to provide this.
-    protected static ?TestResponse $latestResponse = null;
+    public static ?TestResponse $latestResponse = null;
 
     protected function getPackageProviders($app): array
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -3,14 +3,10 @@
 namespace Akaunting\Money\Tests;
 
 use Akaunting\Money\Provider;
-use Illuminate\Testing\TestResponse;
 use Orchestra\Testbench\TestCase as BaseTestCase;
 
 class TestCase extends BaseTestCase
 {
-    // Older Testbench releases expect the concrete test case to provide this.
-    public static ?TestResponse $latestResponse = null;
-
     protected function getPackageProviders($app): array
     {
         return [Provider::class];


### PR DESCRIPTION
- Add ^13 to illuminate/* constraints
- Add orchestra/testbench ^11 for Laravel 13
- Add Laravel 13 and PHP 8.5 to the CI matrix
- Bump actions/checkout to v5 (Node.js 24)
- Add fail-fast: false to CI matrix

Laravel 11 prefer-lowest jobs fail due to a pre-existing static::$latestResponse bug in orchestra/testbench-core 9.0.0 the library itself works fine with Laravel 11.